### PR TITLE
Add post columns

### DIFF
--- a/app/graphql/mutations/create_post.rb
+++ b/app/graphql/mutations/create_post.rb
@@ -4,13 +4,16 @@ module Mutations
     argument :user_id, Integer, required: true
     argument :latitude, Float, required: true
     argument :longitude, Float, required: true
+    argument :url, String, required: false
+    argument :post_type, String, required: true
+    
 
     field :post, Types::PostType, null: false
     field :errors, [String], null: false
 
-    def resolve(content: nil, user_id: nil, latitude: nil, longitude: nil)
-      post = Post.new(content: content, user_id: user_id, latitude: latitude, longitude: longitude)
-      if post.save 
+    def resolve(content: nil, user_id: nil, latitude: nil, longitude: nil, url: nil, post_type: nil)
+      post = Post.new(content: content, user_id: user_id, latitude: latitude, longitude: longitude, url: url, post_type: post_type)
+      if post.save
         {
           post: post,
           errors: []
@@ -24,3 +27,5 @@ module Mutations
     end
   end
 end
+
+# post = Post.create!(content: "content", user_id: 1, latitude: 33.33, longitude: 11.11, url: "url.com", post_type: "Like")

--- a/app/graphql/types/post_type.rb
+++ b/app/graphql/types/post_type.rb
@@ -8,5 +8,8 @@ module Types
     field :likers, [UserType], null: false
     field :ring_min_max, String, null: false
     field :created_at, String, null: false
+    field :url, String, null: false
+    field :post_type, String, null: false
+    
   end
 end

--- a/db/migrate/20210109213732_change_post_columns.rb
+++ b/db/migrate/20210109213732_change_post_columns.rb
@@ -1,0 +1,6 @@
+class ChangePostColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :url, :string
+    add_column :posts, :post_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_20_063016) do
+ActiveRecord::Schema.define(version: 2021_01_09_213732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 2020_12_20_063016) do
     t.integer "ring_min_max", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url"
+    t.string "post_type"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -7,5 +7,7 @@ FactoryBot.define do
     latitude { Faker::Address.latitude }
     longitude { Faker::Address.longitude }
     ring_min_max { 1 }
+    url { "url.com" }
+    post_type { "Link" }
   end
 end

--- a/spec/graphql/mutations/posts/create_post_spec.rb
+++ b/spec/graphql/mutations/posts/create_post_spec.rb
@@ -6,6 +6,7 @@ module Mutations
       describe '.resolve' do
         it 'creates a post' do
           user = create(:user)
+          # binding.pry
           expect do
             post '/graphql', params: { query: query(user_id: user.id) }
           end.to change { Post.count }.by(1)
@@ -25,7 +26,9 @@ module Mutations
             'longitude'       => -104.8897193,
             'createdAt'       => be_present,
             'userId'          => user.id,
-            'ringMinMax'      => "[0, 1]"
+            'ringMinMax'      => "[0, 1]",
+            'url'             => "url.com",
+            'postType'        => "Link"
           )
         end
 
@@ -37,9 +40,11 @@ module Mutations
             createPost(input:
               {
                 userId: #{user_id},
-                content: "Testy testy test",
-                latitude: 39.6930795,
+                content: "Testy testy test"
+                latitude: 39.6930795
                 longitude: -104.8897193
+                url: "url.com"
+                postType: "Link"
               }
             )
             {
@@ -50,7 +55,9 @@ module Mutations
                 longitude,
                 ringMinMax,
                 createdAt,
-                userId
+                userId,
+                url,
+                postType
               }
             }
           }

--- a/spec/graphql/mutations/users/destroy_user_spec.rb
+++ b/spec/graphql/mutations/users/destroy_user_spec.rb
@@ -6,7 +6,6 @@ module Mutations
       describe '.resolve' do
         it 'deletes a user' do
           user = create(:user, password: "password")
-
           # Creates a user here
           expect do
             post '/graphql', params: { query: createUser(username: "New User") }


### PR DESCRIPTION
Added `url` and `post_type` columns to `Posts`.  Did not change `content` column name as previously discussed.  New example createPost:

`
        mutation {
          createPost(input:{
            userId: 1
            content: "test"
            latitude: 1.11
            longitude: 2.22
            url: "2.com"
            postType: "Testing"
          })
          {
            post{
                id,
                content,
                latitude,
                longitude,
                ringMinMax,
                createdAt,
                userId,
              	url,
              	postType
              
            }
          }
        }
`